### PR TITLE
Add Vercel configuration to disable builds on non-main branches

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"git": {
+		"deploymentEnabled": {
+			"main": true,
+			"*": false
+		}
+	}
+}


### PR DESCRIPTION
Introduce a configuration for Vercel to ensure that deployments only occur from the main branch, preventing builds from other branches.